### PR TITLE
set esp32-c3 min freq to 80

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -131,7 +131,7 @@ namespace FujitsuAC {
         String chip = ESP.getChipModel();
 
         if (chip == "ESP32-C3") {
-            minFreq = 40;
+            minFreq = 80;
             maxFreq = 160;
         }
 


### PR DESCRIPTION
bump minimum CPU frequency to 80MHz to prevent native USB and WiFi clock starvation