### PR TITLE
Fix non-ASCII SSIDs failing in config portal (missing UTF-8 charset declaration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ When building DIY dongle, you have attach LEDS to the correspinding pins (Red - 
 * Only red shining - AP is created
 * Red + White shining - connected to wifi and mqtt
 
+### The dongle won't connect to my WiFi after submitting the config page
+If your WiFi SSID or password contains special characters (for example `é` in `witte-rené`), older firmware saves them incorrectly when submitted through the config page, and the dongle never connects. This is fixed in newer firmware, but if you are stuck on an older version you can send the credentials directly with curl, which avoids the browser encoding problem:
+
+1. Connect to the *faircon-uniqueId* access point
+2. Run this from a terminal, with your own values filled in:
+
+```
+curl 'http://192.168.1.1/' \
+  --data-raw 'wifi-ssid=witte-rené&wifi-pw=WIFI_PASSWORD&mqtt-ip=192.168.1.100&mqtt-port=1883&mqtt-user=MQTT_USER&mqtt-pw=MQTT_PASSWORD&device-name=bedroom_ac&ota-pw=OTA_PASSWORD&protocol=UTY-TFSXW1'
+```
+
+Note: the values are sent as-is, so this won't work if a value itself contains `&`, `=` or `+`.
+
 ### What's AP fallback mode?
 When wifi gets disconnected, the dongle reboots to AP mode for several minutes (credentials are not cleared yet, they just are not shown in AP webpage). If Wifi becomes available when AP is enabled, the dongle reboots after a couple minutes to normal mode and connects to it.
 

--- a/src/FujitsuAC.cpp
+++ b/src/FujitsuAC.cpp
@@ -340,6 +340,7 @@ namespace FujitsuAC {
             const char *contentStart = R"rawliteral(
                 <html>
                     <head>
+                        <meta charset="utf-8">
                         <title>faircon</title>
 
                         <style>
@@ -467,7 +468,7 @@ namespace FujitsuAC {
             const char *versionBody = "<strong>" VERSION "</strong>";
 
             const char *formBody = R"rawliteral(
-                <form name="config" method="post">
+                <form name="config" method="post" accept-charset="UTF-8">
                     <label>Wifi SSID</label>
                     <input type="text" name="wifi-ssid" required>
 
@@ -526,7 +527,7 @@ namespace FujitsuAC {
                             this->parseConfig(body);
 
                             client.println("HTTP/1.1 200 OK");
-                            client.println("Content-type:text/html");
+                            client.println("Content-type: text/html; charset=utf-8");
                             client.println();
                             
                             client.print(contentStart);
@@ -546,7 +547,7 @@ namespace FujitsuAC {
                 }
 
                 client.println("HTTP/1.1 200 OK");
-                client.println("Content-type:text/html");
+                client.println("Content-type: text/html; charset=utf-8");
                 client.println();
 
                 client.print(contentStart);


### PR DESCRIPTION
## Problem

When the WiFi SSID contains a special character (mine is `witte-rené`), the config page saves the wrong bytes and the dongle never connects. Posting the same data raw with curl works fine.

## Root cause

The config page does not declare a character encoding. Browsers then fall back to windows-1252 and submit `é` as `%E9` (one byte) instead of UTF-8 `%C3%A9` (two bytes). The saved SSID no longer matches the router's real SSID, so `WiFi.begin()` fails. curl works because it sends the raw UTF-8 bytes without any percent-encoding.

## Fix

Declare UTF-8 in the three standard places (string literals only, no logic changed):

- `<meta charset="utf-8">` in the page head
- `Content-type: text/html; charset=utf-8` on both HTTP responses
- `accept-charset="UTF-8"` on the form

The existing decoder already handles every UTF-8 percent sequence correctly (verified with a host-side test of the exact `urlDecode()` body); the only missing piece was making the browser send UTF-8. Once the charset is declared, the payload arrives as `%C3%A9` and decodes to the right bytes end-to-end.

Also added a FAQ entry to the README with the curl workaround for anyone stuck on older firmware.

## Testing done

I hit this bug on a real device with SSID `witte-rené`. Happy to re-flash with this branch and confirm on hardware if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)