### PR TITLE
Add hvac_action support (action_topic) to climate entity

### DIFF
--- a/src/TFSXW1Bridge.cpp
+++ b/src/TFSXW1Bridge.cpp
@@ -116,6 +116,7 @@ namespace FujitsuAC {
 
         p += "\"mode_command_topic\": \"fujitsu/" + _config.getUniqueId() + "/set/mode\",";
         p += "\"mode_state_topic\": \"fujitsu/" + _config.getUniqueId() + "/state/mode\",";
+        p += "\"action_topic\": \"fujitsu/" + _config.getUniqueId() + "/state/action\",";
 
         p += "\"temperature_command_topic\": \"fujitsu/" + _config.getUniqueId() + "/set/temp\",";
         p += "\"temperature_state_topic\": \"fujitsu/" + _config.getUniqueId() + "/state/temp\",";
@@ -429,6 +430,15 @@ namespace FujitsuAC {
         }
 
         this->publishState(reg->address, this->valueToString(reg));
+
+        if (
+            TFSXW1Controller::Address::Power == reg->address
+            || TFSXW1Controller::Address::Mode == reg->address
+            || TFSXW1Controller::Address::SetpointTemp == reg->address
+            || TFSXW1Controller::Address::ActualTemp == reg->address
+        ) {
+            this->publishActionState();
+        }
 
         if (TFSXW1Controller::Address::Power == reg->address) {
             // Always clear pending auto power-on when any real power state arrives.
@@ -835,5 +845,71 @@ namespace FujitsuAC {
         }
 
         return def;
+    }
+
+    void TFSXW1Bridge::publishActionState() {
+        RegistryTable::Register* powerReg = _controller->getRegister(TFSXW1Controller::Address::Power);
+        RegistryTable::Register* modeReg = _controller->getRegister(TFSXW1Controller::Address::Mode);
+        RegistryTable::Register* setpointReg = _controller->getRegister(TFSXW1Controller::Address::SetpointTemp);
+        RegistryTable::Register* actualReg = _controller->getRegister(TFSXW1Controller::Address::ActualTemp);
+
+        if (nullptr == powerReg || nullptr == modeReg) {
+            return;
+        }
+
+        const char* nextAction = "idle";
+
+        bool isOff = !this->isPoweringOn && !_controller->isPoweredOn();
+        if (isOff) {
+            nextAction = "off";
+        } else {
+            TFSXW1Enums::Mode mode = static_cast<TFSXW1Enums::Mode>(modeReg->value);
+            if (mode == TFSXW1Enums::Mode::Fan) {
+                nextAction = "fan";
+            } else if (mode == TFSXW1Enums::Mode::Dry) {
+                nextAction = "drying";
+            } else if (nullptr == setpointReg || nullptr == actualReg || setpointReg->value == 0xFFFF || actualReg->value == 0xFFFF) {
+                if (mode == TFSXW1Enums::Mode::Cool) {
+                    nextAction = "cooling";
+                } else if (mode == TFSXW1Enums::Mode::Heat) {
+                    nextAction = "heating";
+                } else {
+                    nextAction = "idle";
+                }
+            } else {
+                float target_temp = setpointReg->value / 10.0f;
+                float current_temp = (static_cast<int>(actualReg->value) - 5025) / 100.0f;
+                constexpr float TEMPERATURE_TOLERANCE = 0.5f;
+
+                if (mode == TFSXW1Enums::Mode::Cool) {
+                    if (current_temp + TEMPERATURE_TOLERANCE >= target_temp) {
+                        nextAction = "cooling";
+                    } else {
+                        nextAction = "idle";
+                    }
+                } else if (mode == TFSXW1Enums::Mode::Heat) {
+                    if (current_temp - TEMPERATURE_TOLERANCE <= target_temp) {
+                        nextAction = "heating";
+                    } else {
+                        nextAction = "idle";
+                    }
+                } else if (mode == TFSXW1Enums::Mode::Auto) {
+                    if (current_temp >= target_temp + TEMPERATURE_TOLERANCE) {
+                        nextAction = "cooling";
+                    } else if (current_temp <= target_temp - TEMPERATURE_TOLERANCE) {
+                        nextAction = "heating";
+                    } else {
+                        nextAction = "idle";
+                    }
+                } else {
+                    nextAction = "idle";
+                }
+            }
+        }
+
+        if (this->lastAction != nextAction) {
+            this->lastAction = nextAction;
+            IMqttBridge::publishState("action", nextAction);
+        }
     }
 }

--- a/src/TFSXW1Bridge.h
+++ b/src/TFSXW1Bridge.h
@@ -46,6 +46,9 @@ namespace FujitsuAC {
             void registerClimateEntity();
             void registerSwitch(TFSXW1Controller::Address address);
             void publishState(uint16_t address, const char* value);
+            void publishActionState();
+
+            String lastAction = "";
 
             static const char* addressToString(uint16_t address);
             const char* valueToString(const RegistryTable::Register *reg);


### PR DESCRIPTION
### Summary
This PR adds support for reporting the active operating state (`hvac_action`) of the HVAC unit to Home Assistant. By publishing the current action state, Home Assistant can display the active running badges (e.g., showing the orange flame for active heating, blue snowflake for active cooling, or "idle" when target temperatures are met) on the climate card UI.

For reference, see the Home Assistant [MQTT Climate documentation](https://www.home-assistant.io/integrations/climate.mqtt/#action_topic).

### Implementation Details
* **MQTT Discovery Update**: Added the `"action_topic"` parameter pointing to `fujitsu/<unique_id>/state/action` in the MQTT auto-discovery configuration payload inside `TFSXW1Bridge::registerClimateEntity()`.
* **State Interception**: Monitored changes to the key climate registers (`Power`, `Mode`, `SetpointTemp`, and `ActualTemp`) to trigger a recalculation of the running state.
* **Hysteresis & Calculation Logic**:
  * **Off**: Publishes `off` if the system is turned off.
  * **Fan / Dry**: Publishes `fan` or `drying` directly.
  * **Cool / Heat**: Compares the room temperature (`ActualTemp`) against the target setpoint (`SetpointTemp`) with a standard `0.5°C` hysteresis tolerance to dynamically determine if the unit is actively operating (`cooling`/`heating`) or `idle`.
  * **Auto Mode**: Uses a dual-threshold calculation (cooling if `current >= target + tolerance`, heating if `current <= target - tolerance`, else `idle`).
  * **Fallback**: Defaults to the basic mode (`cooling`/`heating`) if temperature values have not yet finished loading from the mainboard.
* **Deduplication**: Tracks the previous status using a local `lastAction` string variable to ensure the state is only published to MQTT when it actually changes, minimizing broker traffic.

Pictures of PR in action:

<img width="270" height="157" alt="image" src="https://github.com/user-attachments/assets/726ba800-1c52-42ca-936a-18533a685ec8" />
<img width="580" height="593" alt="image" src="https://github.com/user-attachments/assets/f90132de-8bde-49b6-a4c0-7f625acb0147" />
