### PR TITLE
ci: compile-check examples on every push and PR

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,77 @@
+name: Compile Examples
+
+# Compile-checks the library against every supported ESP32 target on each push
+# and pull request, so a change that breaks the firmware build is caught before
+# it reaches master (and before it is offered to deployed dongles via OTA).
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "src/**"
+      - "examples/**"
+      - "library.properties"
+      - ".github/workflows/compile-examples.yml"
+  pull_request:
+    paths:
+      - "src/**"
+      - "examples/**"
+      - "library.properties"
+      - ".github/workflows/compile-examples.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile:
+    name: ${{ matrix.board.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        board:
+          # Bare FQBN = the board's default partition table
+          # ("Default 4MB with spiffs", 1.2 MB APP / 1.5 MB SPIFFS). That is the
+          # scheme the released fw/*.bin are built with and what the deployed
+          # fleet runs; the partition table is not OTA-updatable, so CI must
+          # match it. A change that overflows the 1.2 MB app partition on any
+          # target should fail here.
+          - name: ESP32
+            fqbn: esp32:esp32:esp32
+          - name: ESP32-S3
+            fqbn: esp32:esp32:esp32s3
+          - name: ESP32-C3
+            fqbn: esp32:esp32:esp32c3
+          - name: ESP32-C6
+            fqbn: esp32:esp32:esp32c6
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compile
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+          # Pinned to the toolchain used to build the released fw/*.bin.
+          # Bump deliberately, in sync with the release build setup.
+          platforms: |
+            - name: esp32:esp32
+              version: "3.3.5"
+          libraries: |
+            - name: PubSubClient
+              version: "2.8"
+            - source-path: ./
+          # Only Controller is a buildable end-user sketch today.
+          # Sniffer and DummyUnit are work-in-progress and are intentionally
+          # excluded until they compile again.
+          sketch-paths: |
+            - examples/Controller
+          enable-deltas-report: false
+          verbose: false


### PR DESCRIPTION
Adds a GitHub Actions workflow (`arduino/compile-sketches`) that builds `examples/Controller` against all four supported ESP32 targets — **esp32, esp32-s3, esp32-c3, esp32-c6** — on every push to `master` and every pull request.

### Why

Nothing currently guarantees the firmware compiles, and `NetworkUpdater` serves `fw/*.bin` to deployed dongles straight from `master` HEAD — so a build break on `master`, or on a single chip target, reaches users. Smallest useful first step; broader plan in #56.

### What's in it

- 4-way FQBN matrix, `fail-fast: false`, so every target's result is visible.
- Toolchain pinned to your release build setup (from the discussion below): **esp32 core `3.3.5`**, **PubSubClient `2.8`**.
- **Default partition table** ("Default 4MB with spiffs", 1.2 MB APP / 1.5 MB SPIFFS) — the scheme the released `fw/*.bin` are built with and what the deployed fleet runs. The partition table is not OTA-updatable, so CI matches it: a green run means the shipped image still fits the 1.2 MB app partition, and a change that overflows it fails here.
- `PubSubClient` from Library Manager; repo added as a library via `source-path: ./`.
- `paths:` filter, `concurrency` cancel-in-progress, `permissions: contents: read`.

### Deliberately not included

- `examples/Sniffer` (references removed `Buffer::setup()`) and `examples/DummyUnit` (`.h`/`.cpp` commented out) — excluded from the matrix, tracked in #56.
- Building/attaching `fw/*.bin` — separate change.

### Verified on a fork

All 4 targets green with the pinned toolchain — [run](https://github.com/skolima/FujitsuAC/actions/runs/34199623798):

| target | flash (of 1,310,720 B) |
| --- | --- |
| ESP32 | 1,180,219 B — 90% |
| ESP32-S3 | 1,164,095 B — 88% |
| ESP32-C3 | 1,256,940 B — 95% |
| ESP32-C6 | 1,268,532 B — 96% |

A deliberately broken source file failed all 4 jobs at `Compilation failed`, confirming the check gates ([earlier run](https://github.com/skolima/FujitsuAC/actions/runs/34051200961)).

C3/C6 are close to the app-partition ceiling — not a problem for this PR, but the workflow will now surface it on any change that grows the image. Happy to open a Discussion about headroom separately.

### Pre-existing, not addressed here

`Controller.ino` emits `"LED_W"` / `"RXD2"` `redefined` warnings (`#define` then `#elif #define` without `#undef`). Harmless; flagging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)