### PR TITLE
fix: free the WiFiClientSecure used for the daily version check

### DIFF
--- a/src/NetworkUpdater.cpp
+++ b/src/NetworkUpdater.cpp
@@ -68,12 +68,15 @@ namespace FujitsuAC {
 
 			_lastVersionCheckInitiatedAtMillis = millis();
 
+			// Guard against re-entry with a live client (e.g. the 24h timer
+			// firing while a check is still in HTTPS_DOWNLOADING).
+			this->closeClient();
+
 			_client = new WiFiClientSecure();
 			_client->setCACert(rootCACertificate);
 
 			if (!_client->connect("raw.githubusercontent.com", 443)) {
-				_client->stop();
-			    _client = nullptr;
+				this->closeClient();
 				
 				this->debug("info", "NetworkUpdater: Check last version ERR1");
 
@@ -92,8 +95,7 @@ namespace FujitsuAC {
 				this->debug("info", "NetworkUpdater: Check last version connected");
 				_versionCheckerState = VersionCheckerState::HTTPS_DOWNLOADING;
 			} else {
-				_client->stop();
-			    _client = nullptr;
+				this->closeClient();
 
 			    this->debug("info", "NetworkUpdater: Check last version ERR2");
 				_versionCheckerState = VersionCheckerState::ERROR;
@@ -108,8 +110,7 @@ namespace FujitsuAC {
 					String line = _client->readStringUntil('\n');
 
 					if (line.startsWith("version=")) {
-					    _client->stop();
-					    _client = nullptr;
+					    this->closeClient();
 
 					    _versionCheckerState = VersionCheckerState::VERSION_CHECKED;
 					    this->onVersionReceivedCallback(line.substring(8).c_str());
@@ -119,14 +120,23 @@ namespace FujitsuAC {
 				return;
 			}
 
-			_client->stop();
-		    _client = nullptr;
+			this->closeClient();
 
 		    this->debug("info", "NetworkUpdater: Check last version ERR3");
 			_versionCheckerState = VersionCheckerState::ERROR;
 
 			return;
 		}
+	}
+
+	void NetworkUpdater::closeClient() {
+		if (nullptr == _client) {
+			return;
+		}
+
+		_client->stop();
+		delete _client;
+		_client = nullptr;
 	}
 
 	void NetworkUpdater::updateFirmware(const char *branch) {

--- a/src/NetworkUpdater.h
+++ b/src/NetworkUpdater.h
@@ -93,6 +93,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 -----END CERTIFICATE-----
 				)string_literal";
 
+			void closeClient();
 			void setClock();
 			void requestVersion();
 			void debug(const char* name, const char* message);


### PR DESCRIPTION
`NetworkUpdater::requestVersion()` allocates a `WiFiClientSecure` with `new` on every version check, but each of the four exit paths only calls `stop()` and clears the pointer — the object is never `delete`d.

`stop()` does release the mbedTLS session memory (`stop_ssl_socket()` frees the parsed CA chain, the SSL contexts and the entropy/DRBG pools), so this is a slow leak rather than a fast one. What is left behind is the `WiFiClientSecure` instance plus its by-value `sslclient_context` — on the order of 2 KB per check. At one check per 24 h that is roughly 60 KB a month, unbounded, on a device meant to run for years without a reboot. When the heap eventually runs out the symptom is a crash into the fallback AP, which looks like a Wi-Fi fault rather than a memory one.

### Changes

- Replace the four `stop()` / `= nullptr` pairs with a `closeClient()` helper that also `delete`s.
- Call `closeClient()` before the `new`. The 24 h timer at the top of `requestVersion()` resets the state machine to `TIME_OBTAINED` unconditionally, so a check still sitting in `HTTPS_DOWNLOADING` would otherwise allocate over a live pointer.

No other behaviour change — same state machine, same request, same error paths.

### Testing

Compiled locally with arduino-cli 1.5.1 against the pins the CI workflow uses (esp32 core 3.3.5, PubSubClient 2.8, default partition table). All four targets build, before and after:

| Target | before | after | delta |
|---|---|---|---|
| ESP32 | 1 180 251 | 1 180 319 | +68 B |
| ESP32-S3 | 1 164 127 | 1 164 195 | +68 B |
| ESP32-C3 | 1 256 964 | 1 257 022 | +58 B |
| ESP32-C6 | 1 268 572 | 1 268 630 | +58 B |

RAM usage is unchanged on all four and no flash percentage moved.

Not yet soak-tested on hardware — the leak takes months to show, so this is a code-reading fix rather than one reproduced in the field. I have two dongles (ASYG09KMCE / ASYG07KMCE) running master if you want anything checked on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
