### PR TITLE
fix: bound the UART frame buffer + add host tests (Buffer)

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -1,0 +1,47 @@
+name: Host Tests
+
+# Compiles and runs the hardware-independent logic in src/ on the CI host, under
+# AddressSanitizer + UndefinedBehaviorSanitizer. Catches memory-safety and UB
+# regressions in the protocol code (frame assembly, checksums) that a
+# compile-only check cannot - see test/README.md.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "src/**"
+      - "test/**"
+      - ".github/workflows/host-tests.yml"
+  pull_request:
+    paths:
+      - "src/**"
+      - "test/**"
+      - ".github/workflows/host-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  buffer:
+    name: Buffer frame assembler
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compile (g++, ASan + UBSan, warnings as errors)
+        run: |
+          g++ -std=c++17 -Wall -Wextra -Werror \
+              -fsanitize=address,undefined -fno-sanitize-recover=all -g -O1 \
+              -I test/host -I src \
+              test/host/test_buffer.cpp src/Buffer.cpp \
+              -o test_buffer
+
+      - name: Run
+        run: ./test_buffer

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -21,8 +21,27 @@ namespace FujitsuAC {
             }
 
             this->lastMillis = now;
+
+            // currentIndex is only reset on a >= 20 ms inter-byte gap, so a noisy
+            // bus keeps appending within one "frame". buffer[4] is the length
+            // byte and is peer-supplied: up to 255, i.e. a claimed frame of
+            // buffer[4] + 7 = 262 bytes against uint8_t buffer[128]. Without this
+            // guard the write below walks off the end of the buffer.
+            if (this->currentIndex >= (int) sizeof(this->buffer)) {
+                this->currentIndex = 0;
+                continue;
+            }
+
             this->buffer[this->currentIndex] = b;
             this->currentIndex++;
+
+            // Drop a frame that cannot fit as soon as its length byte is known,
+            // so a bad length byte resynchronises here instead of consuming the
+            // next sizeof(buffer) bytes off the bus first.
+            if (this->currentIndex == 5 && (int) this->buffer[4] + 7 > (int) sizeof(this->buffer)) {
+                this->currentIndex = 0;
+                continue;
+            }
 
             if (this->currentIndex > 4 && this->currentIndex == (int) this->buffer[4] + 7) {
                 if (callback) {

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,35 @@
+# Host tests
+
+Tests for the hardware-independent logic in `src/` - the parts that need no
+ESP32 to exercise (UART frame assembly, checksums, protocol state). They compile
+against a tiny stub of the Arduino core in `host/Arduino.h` and run on any
+desktop.
+
+CI runs them under AddressSanitizer + UndefinedBehaviorSanitizer
+(`.github/workflows/host-tests.yml`), which is where memory-safety bugs in the
+protocol code surface.
+
+## Running locally
+
+```sh
+g++ -std=c++17 -Wall -Wextra -Werror \
+    -fsanitize=address,undefined -fno-sanitize-recover=all -g -O1 \
+    -I test/host -I src \
+    test/host/test_buffer.cpp src/Buffer.cpp \
+    -o test_buffer
+./test_buffer
+```
+
+`clang++` works too. Drop `-fsanitize=...` if your toolchain has no sanitizer
+runtime (e.g. stock MinGW) - the assertions still run, but a buffer overrun then
+shows up as a plain crash rather than a diagnosed one.
+
+## Layout
+
+| Path | What it is |
+| --- | --- |
+| `host/Arduino.h` | Minimal Arduino-core stub: `Stream`, `millis()`. Extend only as sources under test require. |
+| `host/test_buffer.cpp` | Tests for `FujitsuAC::Buffer`, plus a ~30-line assert harness and `main()`. |
+
+Adding a suite: put `test_<unit>.cpp` in `host/`, add whatever core symbols it
+needs to `host/Arduino.h`, and add a compile+run step (or job) to the workflow.

--- a/test/host/Arduino.h
+++ b/test/host/Arduino.h
@@ -1,0 +1,30 @@
+/*
+  FujitsuAC - ESP32 libary for controlling FujitsuAC through MQTT
+  Copyright (c) 2025 Benas Ragauskas. All rights reserved.
+
+  Project home: https://github.com/Benas09/FujitsuAC
+*/
+
+// Minimal host stand-in for the Arduino core: just enough of it to compile the
+// hardware-independent sources under src/ off-device for the tests in this
+// directory. This is not a general Arduino emulation - add only what a source
+// under test actually needs.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+
+// Arduino's millis(). The test binary provides the definition and drives the
+// clock so time-dependent behaviour (the inter-frame gap) is deterministic.
+unsigned long millis();
+
+// Arduino's Stream, pared down to the two methods Buffer uses.
+class Stream {
+    public:
+        virtual ~Stream() = default;
+
+        virtual int available() = 0;
+        virtual int read() = 0;
+        virtual int peek() { return -1; }
+};

--- a/test/host/test_buffer.cpp
+++ b/test/host/test_buffer.cpp
@@ -1,0 +1,237 @@
+/*
+  FujitsuAC - ESP32 libary for controlling FujitsuAC through MQTT
+  Copyright (c) 2025 Benas Ragauskas. All rights reserved.
+
+  Project home: https://github.com/Benas09/FujitsuAC
+*/
+
+// Host-native tests for FujitsuAC::Buffer - the UART frame assembler in
+// src/Buffer.cpp. No board required: compile with the stub in test/host/Arduino.h
+// and run (see test/README.md). Against a Buffer::loop without the frame-length
+// guards, dropsAFrameLongerThanTheBuffer overruns buffer[128] and the process
+// crashes - a diagnosed heap-buffer-overflow under -fsanitize=address, a
+// SIGSEGV without it.
+
+#include "Arduino.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <initializer_list>
+#include <memory>
+#include <vector>
+
+#include "Buffer.h"
+
+using FujitsuAC::Buffer;
+
+// --- host clock -------------------------------------------------------------
+static unsigned long g_now = 0;
+unsigned long millis() { return g_now; }
+
+// --- fake UART -------------------------------------------------------------
+class FakeStream : public Stream {
+    public:
+        void feed(std::initializer_list<uint8_t> bytes) {
+            queue_.insert(queue_.end(), bytes.begin(), bytes.end());
+        }
+        void feed(const std::vector<uint8_t> &bytes) {
+            queue_.insert(queue_.end(), bytes.begin(), bytes.end());
+        }
+
+        int available() override { return static_cast<int>(queue_.size() - pos_); }
+        int read() override { return pos_ < queue_.size() ? queue_[pos_++] : -1; }
+
+    private:
+        std::vector<uint8_t> queue_;
+        std::size_t pos_ = 0;
+};
+
+// --- tiny assert harness --------------------------------------------------
+static int g_checks = 0;
+static int g_failed = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                      \
+        ++g_checks;                                                           \
+        if (!(cond)) {                                                        \
+            ++g_failed;                                                       \
+            std::printf("  FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);     \
+        }                                                                     \
+    } while (0)
+
+// --- helpers -------------------------------------------------------------
+struct CapturedFrame {
+    std::vector<uint8_t> bytes;
+    int size = 0;
+    bool valid = false;
+};
+
+// Append the trailing 16-bit checksum Buffer::isValidFrame expects: 0xFFFF
+// minus every preceding byte, big-endian.
+static std::vector<uint8_t> withChecksum(std::vector<uint8_t> frame) {
+    uint16_t checksum = 0xFFFF;
+    for (uint8_t b : frame) {
+        checksum -= b;
+    }
+    frame.push_back(static_cast<uint8_t>(checksum >> 8));
+    frame.push_back(static_cast<uint8_t>(checksum & 0xFF));
+    return frame;
+}
+
+// A well-formed frame: bytes 0..3 zero, byte 4 = payloadLen, payload zeroed,
+// then the checksum. Total length is payloadLen + 7, matching Buffer's
+// buffer[4] + 7.
+static std::vector<uint8_t> makeFrame(uint8_t payloadLen) {
+    std::vector<uint8_t> frame(5 + payloadLen, 0x00);
+    frame[4] = payloadLen;
+    return withChecksum(std::move(frame));
+}
+
+static std::vector<CapturedFrame> run(Buffer &buffer) {
+    std::vector<CapturedFrame> frames;
+    buffer.loop([&frames](uint8_t data[128], int size, bool isValid) {
+        CapturedFrame f;
+        f.size = size;
+        f.valid = isValid;
+        if (size > 0 && size <= 128) {
+            f.bytes.assign(data, data + size);
+        }
+        frames.push_back(f);
+    });
+    return frames;
+}
+
+// --- tests -------------------------------------------------------------
+// The real UTY-TFSXW1 "Init1" reply, straight from TFSXW1Controller.
+static const std::vector<uint8_t> kInit1Reply = {
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0xFF, 0xFD};
+
+static void deliversAValidFrame() {
+    std::printf("deliversAValidFrame\n");
+    FakeStream uart;
+    auto buffer = std::make_unique<Buffer>(uart);
+
+    uart.feed(kInit1Reply);
+    auto frames = run(*buffer);
+
+    CHECK(frames.size() == 1);
+    if (frames.size() == 1) {
+        CHECK(frames[0].size == 8);
+        CHECK(frames[0].valid);
+        CHECK(frames[0].bytes == kInit1Reply);
+    }
+}
+
+static void flagsABadChecksum() {
+    std::printf("flagsABadChecksum\n");
+    FakeStream uart;
+    auto buffer = std::make_unique<Buffer>(uart);
+
+    std::vector<uint8_t> corrupt = kInit1Reply;
+    corrupt.back() ^= 0xFF;
+    uart.feed(corrupt);
+    auto frames = run(*buffer);
+
+    CHECK(frames.size() == 1);
+    if (frames.size() == 1) {
+        CHECK(frames[0].size == 8);
+        CHECK(!frames[0].valid);
+    }
+}
+
+static void resynchronisesAfterInterByteGap() {
+    std::printf("resynchronisesAfterInterByteGap\n");
+    FakeStream uart;
+    auto buffer = std::make_unique<Buffer>(uart);
+
+    // A partial/garbled burst, then a >= 20 ms gap, then a clean frame.
+    uart.feed({0x03, 0x11, 0x22});
+    run(*buffer);
+
+    g_now += 25;
+    uart.feed(kInit1Reply);
+    auto frames = run(*buffer);
+
+    CHECK(frames.size() == 1);
+    if (frames.size() == 1) {
+        CHECK(frames[0].valid);
+        CHECK(frames[0].bytes == kInit1Reply);
+    }
+}
+
+static void dropsAFrameLongerThanTheBuffer() {
+    std::printf("dropsAFrameLongerThanTheBuffer\n");
+    FakeStream uart;
+    auto buffer = std::make_unique<Buffer>(uart);
+
+    // Length byte 0xFF => a claimed 262-byte frame. Feed well over 128 bytes
+    // with no inter-byte gap. Without the guards in Buffer::loop this overruns
+    // buffer[128] and the process crashes here; with them the frame is dropped.
+    std::vector<uint8_t> flood(400, 0x00);
+    flood[4] = 0xFF;
+    uart.feed(flood);
+    auto frames = run(*buffer);
+
+    for (const auto &f : frames) {
+        CHECK(f.size <= 128);
+    }
+    // Nothing valid can come out of an all-zero flood.
+    for (const auto &f : frames) {
+        CHECK(!f.valid);
+    }
+}
+
+static void acceptsTheLargestFittingFrame() {
+    std::printf("acceptsTheLargestFittingFrame\n");
+    FakeStream uart;
+    auto buffer = std::make_unique<Buffer>(uart);
+
+    // payloadLen 121 => total 128, exactly sizeof(buffer). Must still be
+    // delivered - the "too long" check has to be strictly greater-than.
+    auto frame = makeFrame(121);
+    CHECK(frame.size() == 128);
+    uart.feed(frame);
+    auto frames = run(*buffer);
+
+    CHECK(frames.size() == 1);
+    if (frames.size() == 1) {
+        CHECK(frames[0].size == 128);
+        CHECK(frames[0].valid);
+    }
+}
+
+static void survivesContinuousNoise() {
+    std::printf("survivesContinuousNoise\n");
+    FakeStream uart;
+    auto buffer = std::make_unique<Buffer>(uart);
+
+    // 4 KB of deterministic pseudo-random bytes, no gap. The only invariant is
+    // that Buffer never reports a frame larger than its buffer and never
+    // overruns it (ASan).
+    std::uint32_t state = 0x12345678u;
+    std::vector<uint8_t> noise;
+    noise.reserve(4096);
+    for (int i = 0; i < 4096; ++i) {
+        state = state * 1664525u + 1013904223u;
+        noise.push_back(static_cast<uint8_t>(state >> 24));
+    }
+    uart.feed(noise);
+    auto frames = run(*buffer);
+
+    for (const auto &f : frames) {
+        CHECK(f.size >= 5);
+        CHECK(f.size <= 128);
+    }
+}
+
+int main() {
+    deliversAValidFrame();
+    flagsABadChecksum();
+    resynchronisesAfterInterByteGap();
+    dropsAFrameLongerThanTheBuffer();
+    acceptsTheLargestFittingFrame();
+    survivesContinuousNoise();
+
+    std::printf("\n%d checks, %d failed\n", g_checks, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## What

`Buffer::loop` (`src/Buffer.cpp`) appends every incoming UART byte into
`uint8_t buffer[128]` with no bounds check on `currentIndex` — which is only
reset on a >= 20 ms inter-byte gap. The frame length it works toward is
`buffer[4] + 7`, and `buffer[4]` is a byte straight off the bus (up to 255, i.e.
a claimed 262-byte frame). A noisy bus or a malformed long frame walks the write
past the end of `buffer` into the members after it; `isValidFrame` then also
reads `buffer[size - 2]` / `buffer[size - 1]` out of bounds. The dongle falls
back to the AP on the resulting panic, so in the field this looks like a Wi-Fi
glitch rather than a memory bug.

### Fix (`src/Buffer.cpp`, +19 lines)

- Once `currentIndex` reaches `sizeof(buffer)`, drop the byte and resync instead
  of writing.
- As soon as the length byte is in (`currentIndex == 5`), drop the frame if
  `buffer[4] + 7` cannot fit — so a bad length byte resyncs right away instead
  of consuming another `sizeof(buffer)` bytes off the bus first.

Frames up to the full 128-byte buffer are still delivered unchanged; the
"too long" check is strictly greater-than.

## Tests (`test/`)

This overrun needs a specific malformed frame on the bus, so rather than
soak-test on hardware I've brought the fix together with a host-native test that
reproduces it. That also bootstraps the `test/` setup from #56 (phase 4).

- `test/host/Arduino.h` — a ~15-line stub of the core (`Stream`, `millis()`),
  to be extended as sources under test need it.
- `test/host/test_buffer.cpp` — `Buffer` tests plus a small assert harness:
  delivers a real `Init1` reply, flags a bad checksum, resyncs after an
  inter-byte gap, **drops an over-long frame without overrunning**, still
  accepts the largest fitting frame, and survives 4 KB of continuous noise.
- `.github/workflows/host-tests.yml` — compiles and runs them on `ubuntu-latest`
  under `-fsanitize=address,undefined -fno-sanitize-recover=all` and
  `-Wall -Wextra -Werror`.

Against `master`'s `Buffer`, `test_buffer` crashes in the over-long-frame case
(SIGSEGV; a diagnosed heap-buffer-overflow under ASan). With the fix:
`82 checks, 0 failed`. Verified locally with g++ 13 `-Wall -Wextra -Werror`.
The `compile-examples` matrix is unaffected — the Arduino build only compiles
`src/`.

## Not included

No `CHANGELOG.md` / version bump — that's a behaviour change that would ship via
OTA, so I left the release call to you (happy to add a line). The
sanitizer-native, fuzz and static-analysis items from #56 can follow as separate
PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
